### PR TITLE
Expose `strip_regex` for `convert_file` and `convert_text`.

### DIFF
--- a/yaml2rst.py
+++ b/yaml2rst.py
@@ -128,12 +128,12 @@ def convert(lines, strip_regex):
             state = STATE_YAML
 
 
-def convert_text(yaml_text):
-    return '\n'.join(convert(yaml_text.splitlines()))
+def convert_text(yaml_text, strip_regex=None):
+    return '\n'.join(convert(yaml_text.splitlines(), strip_regex))
 
 
-def convert_file(infilename, outfilename):
+def convert_file(infilename, outfilename, strip_regex=None):
     with open(infilename) as infh:
         with open(outfilename, "w") as outfh:
-            for l in convert(infh.readlines()):
+            for l in convert(infh.readlines(), strip_regex):
                 print(l.rstrip(), file=outfh)


### PR DESCRIPTION
Related to: https://github.com/htgoebel/yaml2rst/pull/3

`convert_file` is used in https://github.com/debops/docs
